### PR TITLE
feat: 모듈별 설정 파일 이름 추가

### DIFF
--- a/acm-admin/src/main/kotlin/mashup/backend/spring/acm/AcmAdminApplication.kt
+++ b/acm-admin/src/main/kotlin/mashup/backend/spring/acm/AcmAdminApplication.kt
@@ -7,5 +7,6 @@ import org.springframework.boot.runApplication
 class AcmAdminApplication
 
 fun main(args: Array<String>) {
+    System.setProperty("spring.config.name", "application,admin")
     runApplication<AcmAdminApplication>(*args)
 }

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/AcmApiApplication.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/AcmApiApplication.kt
@@ -7,5 +7,6 @@ import org.springframework.boot.runApplication
 class AcmApiApplication
 
 fun main(args: Array<String>) {
+    System.setProperty("spring.config.name", "application,api")
     runApplication<AcmApiApplication>(*args)
 }

--- a/acm-batch/src/main/kotlin/mashup/backend/spring/acm/AcmApplication.kt
+++ b/acm-batch/src/main/kotlin/mashup/backend/spring/acm/AcmApplication.kt
@@ -7,5 +7,6 @@ import org.springframework.boot.runApplication
 class AcmApplication
 
 fun main(args: Array<String>) {
+	System.setProperty("spring.config.name", "application,batch")
 	runApplication<AcmApplication>(*args)
 }


### PR DESCRIPTION
resolve #17 

application.yml 외에 admin.yml, api.yml, batch.yml 등의 설정 파일이름을 사용할 수 있게 합니다. 

(application.yml 파일을 여러 모듈에서 쓰는 경우, 
domain 의 application.yml 설정파일이 
admin, api, batch 모듈의 application.yml 파일 때문에 가려지는(?) 현상 해결)