### PR TITLE
회원 조회, 가입 로직 추가

### DIFF
--- a/acm-api/build.gradle
+++ b/acm-api/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     api(project(":acm-domain"))
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("com.h2database:h2")

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/Member.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/Member.kt
@@ -1,0 +1,20 @@
+package mashup.backend.spring.acm.domain.member
+
+import mashup.backend.spring.acm.domain.BaseEntity
+import mashup.backend.spring.acm.domain.member.idprovider.MemberIdProvider
+import javax.persistence.Entity
+import javax.persistence.JoinColumn
+import javax.persistence.OneToMany
+import javax.persistence.OneToOne
+
+@Entity
+class Member(
+    val memberStatus: MemberStatus,
+    @OneToOne(mappedBy = "member")
+    val memberDetail: MemberDetail,
+    @OneToMany
+    @JoinColumn(name = "memberId")
+    val memberIdProviders: List<MemberIdProvider>
+) : BaseEntity() {
+
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/Member.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/Member.kt
@@ -2,19 +2,41 @@ package mashup.backend.spring.acm.domain.member
 
 import mashup.backend.spring.acm.domain.BaseEntity
 import mashup.backend.spring.acm.domain.member.idprovider.MemberIdProvider
-import javax.persistence.Entity
-import javax.persistence.JoinColumn
-import javax.persistence.OneToMany
-import javax.persistence.OneToOne
+import javax.persistence.*
 
 @Entity
 class Member(
-    val memberStatus: MemberStatus,
-    @OneToOne(mappedBy = "member")
+    val memberStatus: MemberStatus = MemberStatus.ACTIVE,
+    @OneToOne(cascade = [CascadeType.ALL])
     val memberDetail: MemberDetail,
-    @OneToMany
+    @OneToMany(cascade = [CascadeType.ALL])
     @JoinColumn(name = "memberId")
-    val memberIdProviders: List<MemberIdProvider>
+    val memberIdProviders: MutableList<MemberIdProvider> = ArrayList()
 ) : BaseEntity() {
+    fun add(memberIdProvider: MemberIdProvider) {
+        memberIdProviders.add(memberIdProvider)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Member
+
+        if (memberStatus != other.memberStatus) return false
+        if (memberDetail != other.memberDetail) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = memberStatus.hashCode()
+        result = 31 * result + memberDetail.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "Member(memberStatus=$memberStatus, memberDetail=$memberDetail)"
+    }
 
 }

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/Member.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/Member.kt
@@ -6,9 +6,9 @@ import javax.persistence.*
 
 @Entity
 class Member(
-    val memberStatus: MemberStatus = MemberStatus.ACTIVE,
+    val memberStatus: MemberStatus = MemberStatus.ASSOCIATE,
     @OneToOne(cascade = [CascadeType.ALL])
-    val memberDetail: MemberDetail,
+    val memberDetail: MemberDetail? = null,
     @OneToMany(cascade = [CascadeType.ALL])
     @JoinColumn(name = "memberId")
     val memberIdProviders: MutableList<MemberIdProvider> = ArrayList()

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberDetail.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberDetail.kt
@@ -1,0 +1,39 @@
+package mashup.backend.spring.acm.domain.member
+
+import mashup.backend.spring.acm.domain.BaseEntity
+import java.time.LocalDate
+import java.time.Year
+import javax.persistence.Entity
+import javax.persistence.OneToOne
+
+@Entity
+class MemberDetail(
+    @OneToOne
+    val member: Member,
+    /**
+     * 성별
+     */
+    var gender: String,
+    /**
+     * 출생연도
+     */
+    private var birthYear: Year,
+    /**
+     * 좋아하는 노트
+     */
+    var note: String = "",
+    /**
+     * 좋아하는 향수
+     */
+    var perfume: String = "",
+) : BaseEntity() {
+    /**
+     * 나이
+     */
+    var age: Int = 0
+        set(value) {
+            birthYear = Year.of(LocalDate.now().year - value + 1)
+            field = value
+        }
+        get() = LocalDate.now().year - birthYear.value + 1
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberDetail.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberDetail.kt
@@ -4,12 +4,9 @@ import mashup.backend.spring.acm.domain.BaseEntity
 import java.time.LocalDate
 import java.time.Year
 import javax.persistence.Entity
-import javax.persistence.OneToOne
 
 @Entity
 class MemberDetail(
-    @OneToOne
-    val member: Member,
     /**
      * 성별
      */
@@ -30,10 +27,49 @@ class MemberDetail(
     /**
      * 나이
      */
+    @Transient
     var age: Int = 0
         set(value) {
-            birthYear = Year.of(LocalDate.now().year - value + 1)
+            birthYear = calculateBirthYear(value)
             field = value
         }
-        get() = LocalDate.now().year - birthYear.value + 1
+        get() = calculateAge(birthYear)
+
+    private fun calculateBirthYear(age: Int): Year {
+        return Year.of(LocalDate.now().year - age + 1)
+    }
+
+    private fun calculateAge(birthYear: Year): Int {
+        return LocalDate.now().year - birthYear.value + 1
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as MemberDetail
+
+        if (gender != other.gender) return false
+        if (birthYear != other.birthYear) return false
+        if (note != other.note) return false
+        if (perfume != other.perfume) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = gender.hashCode()
+        result = 31 * result + birthYear.hashCode()
+        result = 31 * result + note.hashCode()
+        result = 31 * result + perfume.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "MemberDetail(gender='$gender', birthYear=$birthYear, note='$note', perfume='$perfume')"
+    }
+
+    init {
+        this.age = calculateAge(birthYear)
+    }
 }

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberRepository.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberRepository.kt
@@ -1,0 +1,8 @@
+package mashup.backend.spring.acm.domain.member
+
+import mashup.backend.spring.acm.domain.member.idprovider.IdProviderInfo
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberRepository: JpaRepository<Member, Long> {
+    fun findByMemberIdProviders_IdProviderInfo(idProviderInfo: IdProviderInfo): Member?
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberService.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberService.kt
@@ -1,12 +1,13 @@
 package mashup.backend.spring.acm.domain.member
 
 import mashup.backend.spring.acm.domain.member.idprovider.IdProviderInfo
+import mashup.backend.spring.acm.domain.member.idprovider.MemberIdProvider
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface MemberService {
     fun findByIdProviderVo(idProviderInfo: IdProviderInfo): Member?
-    fun join(): Member
+    fun join(idProviderInfo: IdProviderInfo): Member
     fun withdraw()
 }
 
@@ -14,14 +15,24 @@ interface MemberService {
 @Transactional(readOnly = true)
 class MemberServiceImpl(
     private val memberRepository: MemberRepository
-): MemberService {
+) : MemberService {
     override fun findByIdProviderVo(idProviderInfo: IdProviderInfo): Member? {
         return memberRepository.findByMemberIdProviders_IdProviderInfo(idProviderInfo)
     }
 
     @Transactional
-    override fun join(): Member {
-        TODO("Not yet implemented")
+    override fun join(idProviderInfo: IdProviderInfo): Member {
+        val member = memberRepository.findByMemberIdProviders_IdProviderInfo(idProviderInfo)
+        if (member != null) {
+            return member
+        }
+        return memberRepository.save(
+            Member(
+                memberIdProviders = arrayListOf(
+                    MemberIdProvider(idProviderInfo = idProviderInfo)
+                )
+            )
+        )
     }
 
     @Transactional

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberService.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberService.kt
@@ -1,0 +1,31 @@
+package mashup.backend.spring.acm.domain.member
+
+import mashup.backend.spring.acm.domain.member.idprovider.IdProviderInfo
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+interface MemberService {
+    fun findByIdProviderVo(idProviderInfo: IdProviderInfo): Member
+    fun join(): Member
+    fun withdraw()
+}
+
+@Service
+@Transactional(readOnly = true)
+class MemberServiceImpl(
+    private val memberRepository: MemberRepository
+): MemberService {
+    override fun findByIdProviderVo(idProviderInfo: IdProviderInfo): Member? {
+        return memberRepository.findByMemberIdProviders_IdProviderInfo(idProviderInfo)
+    }
+
+    @Transactional
+    override fun join(): Member {
+        TODO("Not yet implemented")
+    }
+
+    @Transactional
+    override fun withdraw() {
+        TODO("Not yet implemented")
+    }
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberService.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberService.kt
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface MemberService {
-    fun findByIdProviderVo(idProviderInfo: IdProviderInfo): Member
+    fun findByIdProviderVo(idProviderInfo: IdProviderInfo): Member?
     fun join(): Member
     fun withdraw()
 }

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberStatus.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberStatus.kt
@@ -1,0 +1,9 @@
+package mashup.backend.spring.acm.domain.member
+
+enum class MemberStatus(
+    private val description: String
+) {
+    ACTIVE("일반회원"),
+    ASSOCIATE("준회원"),
+    WITHDRAWAL("탈퇴회원"),
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/idprovider/IdProviderInfo.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/idprovider/IdProviderInfo.kt
@@ -1,0 +1,18 @@
+package mashup.backend.spring.acm.domain.member.idprovider
+
+import javax.persistence.Embeddable
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+
+@Embeddable
+data class IdProviderInfo(
+    /**
+     * 인증제공자 종류
+     */
+    @Enumerated(EnumType.STRING)
+    val idProviderType: IdProviderType,
+    /**
+     * 인증제공자 사용자 식별자
+     */
+    val idProviderUserId: String,
+)

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/idprovider/IdProviderType.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/idprovider/IdProviderType.kt
@@ -1,0 +1,12 @@
+package mashup.backend.spring.acm.domain.member.idprovider
+
+/**
+ * 인증제공자
+ */
+enum class IdProviderType(
+    private val description: String
+){
+    UUID("익명 인증"),
+    APPLE("애플 로그인"),
+    KAKAO("카카오 로그인"),
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/idprovider/MemberIdProvider.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/idprovider/MemberIdProvider.kt
@@ -1,0 +1,22 @@
+package mashup.backend.spring.acm.domain.member.idprovider
+
+import javax.persistence.Embedded
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+
+@Entity
+class MemberIdProvider(
+    /**
+     * 인증제공자 종류, 사용자 식별자
+     */
+    @Embedded
+    val idProviderInfo: IdProviderInfo,
+    /**
+     * 인증제공자 별 사용자 상태
+     */
+    @Enumerated(EnumType.STRING)
+    var memberIdProviderStatus: MemberIdProviderStatus = MemberIdProviderStatus.ACTIVE,
+) {
+
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/idprovider/MemberIdProvider.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/idprovider/MemberIdProvider.kt
@@ -1,5 +1,6 @@
 package mashup.backend.spring.acm.domain.member.idprovider
 
+import mashup.backend.spring.acm.domain.BaseEntity
 import javax.persistence.Embedded
 import javax.persistence.Entity
 import javax.persistence.EnumType
@@ -17,6 +18,28 @@ class MemberIdProvider(
      */
     @Enumerated(EnumType.STRING)
     var memberIdProviderStatus: MemberIdProviderStatus = MemberIdProviderStatus.ACTIVE,
-) {
+): BaseEntity() {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as MemberIdProvider
+
+        if (idProviderInfo != other.idProviderInfo) return false
+        if (memberIdProviderStatus != other.memberIdProviderStatus) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = idProviderInfo.hashCode()
+        result = 31 * result + memberIdProviderStatus.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "MemberIdProvider(idProviderInfo=$idProviderInfo, memberIdProviderStatus=$memberIdProviderStatus)"
+    }
+
 
 }

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/idprovider/MemberIdProviderStatus.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/idprovider/MemberIdProviderStatus.kt
@@ -1,0 +1,8 @@
+package mashup.backend.spring.acm.domain.member.idprovider
+
+enum class MemberIdProviderStatus(
+    private val description: String
+) {
+    ACTIVE("사용중"),
+    INACTIVE("탈퇴")
+}

--- a/acm-domain/src/test/kotlin/mashup/backend/spring/acm/domain/TestConfiguration.kt
+++ b/acm-domain/src/test/kotlin/mashup/backend/spring/acm/domain/TestConfiguration.kt
@@ -1,0 +1,7 @@
+package mashup.backend.spring.acm.domain
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+
+@SpringBootApplication
+class TestConfiguration {
+}

--- a/acm-domain/src/test/kotlin/mashup/backend/spring/acm/domain/member/MemberServiceImplTest.kt
+++ b/acm-domain/src/test/kotlin/mashup/backend/spring/acm/domain/member/MemberServiceImplTest.kt
@@ -20,7 +20,7 @@ internal class MemberServiceImplTest {
     lateinit var sut: MemberService
 
     @Test
-    fun test() {
+    fun findMember() {
         // given
         val idProviderInfo = IdProviderInfo(
             idProviderType = IdProviderType.UUID,
@@ -44,5 +44,18 @@ internal class MemberServiceImplTest {
         )
         member.add(memberIdProvider)
         memberRepository.save(member)
+    }
+
+    @Test
+    fun join() {
+        // given
+        val idProviderInfo = IdProviderInfo(
+            idProviderType = IdProviderType.UUID,
+            idProviderUserId = "idProviderUserId"
+        )
+        // when
+        val actual = sut.join(idProviderInfo)
+        // then
+        assertThat(actual).isNotNull
     }
 }

--- a/acm-domain/src/test/kotlin/mashup/backend/spring/acm/domain/member/MemberServiceImplTest.kt
+++ b/acm-domain/src/test/kotlin/mashup/backend/spring/acm/domain/member/MemberServiceImplTest.kt
@@ -1,0 +1,48 @@
+package mashup.backend.spring.acm.domain.member
+
+import mashup.backend.spring.acm.domain.member.idprovider.IdProviderInfo
+import mashup.backend.spring.acm.domain.member.idprovider.IdProviderType
+import mashup.backend.spring.acm.domain.member.idprovider.MemberIdProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+import java.time.Year
+
+@Transactional
+@SpringBootTest
+internal class MemberServiceImplTest {
+    @Autowired
+    lateinit var memberRepository: MemberRepository
+
+    @Autowired
+    lateinit var sut: MemberService
+
+    @Test
+    fun test() {
+        // given
+        val idProviderInfo = IdProviderInfo(
+            idProviderType = IdProviderType.UUID,
+            idProviderUserId = "uuidUserId"
+        )
+        createMember(idProviderInfo)
+        // when
+        val actual = sut.findByIdProviderVo(idProviderInfo)
+        // then
+        assertThat(actual).isNotNull
+        assertThat(actual!!.memberIdProviders[0].idProviderInfo).isEqualTo(idProviderInfo)
+    }
+
+    private fun createMember(idProviderInfo: IdProviderInfo) {
+        val memberIdProvider = MemberIdProvider(idProviderInfo)
+        val member = Member(
+            memberDetail = MemberDetail(
+                gender = "gender",
+                birthYear = Year.of(1989)
+            )
+        )
+        member.add(memberIdProvider)
+        memberRepository.save(member)
+    }
+}

--- a/acm-domain/src/test/resources/application.yml
+++ b/acm-domain/src/test/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
- 계정 하나에 여러개의 인증 제공자 연동할 수 있는 구조로 만듦
- 회원 조회, 가입 로직 추가
- 탈퇴는 아직 ㅠ
- 나이 대신 태어난 연도를 계산해서 저장하고, 나이는 조회시 동적으로 계산함

![member-diagram](https://user-images.githubusercontent.com/4813025/134757983-28372f8e-f549-41db-b1e7-c4e7d4ed3ea8.png)
