### PR TITLE
api, batch 모두 같은 datasource 사용하도록 변경

### DIFF
--- a/acm-batch/src/main/kotlin/mashup/backend/spring/acm/infrastructure/BatchConfig.kt
+++ b/acm-batch/src/main/kotlin/mashup/backend/spring/acm/infrastructure/BatchConfig.kt
@@ -1,33 +1,13 @@
 package mashup.backend.spring.acm.infrastructure
 
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.autoconfigure.batch.BatchDataSource
-import org.springframework.boot.jdbc.DataSourceBuilder
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import javax.sql.DataSource
 
 
 @EnableBatchProcessing
 @Configuration
-class BatchConfig(
-    @Value("\${spring.batch.datasource.url}")
-    private val url: String,
-    @Value("\${spring.batch.datasource.username}")
-    private val username: String,
-    @Value("\${spring.batch.datasource.password}")
-    private val password: String
-) {
+class BatchConfig {
     companion object {
         const val SPRING_BATCH_JOB_NAMES = "spring.batch.job.names"
     }
-
-    @Bean
-    @BatchDataSource
-    fun batchDataSource(): DataSource = DataSourceBuilder.create()
-        .url(url)
-        .username(username)
-        .password(password)
-        .build()
 }

--- a/acm-batch/src/main/resources/batch-develop.yml
+++ b/acm-batch/src/main/resources/batch-develop.yml
@@ -1,6 +1,0 @@
-spring:
-  batch:
-    datasource:
-      url: jdbc:mysql://acm-db-01.cycmo96vm8ng.ap-northeast-2.rds.amazonaws.com:3306/perfuming_batch_dev?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&DB_CLOSE_ON_EXIT=FALSE
-      username: acm
-      password: ENC(IPNXUg/rPLNb371777vuH6VMgjCZkAqEXXnHGNd1I1QPtVxnyge19oK+BQD99NoF)

--- a/acm-batch/src/main/resources/batch-local.yml
+++ b/acm-batch/src/main/resources/batch-local.yml
@@ -1,6 +1,0 @@
-spring:
-  batch:
-    datasource:
-      url: jdbc:mysql://acm-db-01.cycmo96vm8ng.ap-northeast-2.rds.amazonaws.com:3306/perfuming_batch_dev?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&DB_CLOSE_ON_EXIT=FALSE
-      username: acm
-      password: ENC(IPNXUg/rPLNb371777vuH6VMgjCZkAqEXXnHGNd1I1QPtVxnyge19oK+BQD99NoF)

--- a/acm-batch/src/main/resources/batch-production.yml
+++ b/acm-batch/src/main/resources/batch-production.yml
@@ -1,7 +1,0 @@
-# TODO: add database for batch production
-#spring:
-#  batch:
-#    datasource:
-#      url: jdbc:mysql://acm-db-01.cycmo96vm8ng.ap-northeast-2.rds.amazonaws.com:3306/perfuming_batch_dev?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&DB_CLOSE_ON_EXIT=FALSE
-#      username: acm
-#      password: ENC(IPNXUg/rPLNb371777vuH6VMgjCZkAqEXXnHGNd1I1QPtVxnyge19oK+BQD99NoF)

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/scrap/perfume_url/PerfumeUrlScrapingJobService.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/scrap/perfume_url/PerfumeUrlScrapingJobService.kt
@@ -10,10 +10,15 @@ class PerfumeUrlScrapingJobService(
 ) {
     @Transactional
     fun createIfNotExists(perfumeUrl: String) : Pair<Boolean, PerfumeUrlScrapingJob?> {
-        if (perfumeUrlRepository.existsByUrl(perfumeUrl)) {
+        val url = if (perfumeUrl.startsWith("https://www.fragrantica.com/")) {
+            perfumeUrl
+        } else {
+            "https://www.fragrantica.com$perfumeUrl"
+        }
+        if (perfumeUrlRepository.existsByUrl(url)) {
             return Pair(false, null)
         }
-        val perfumeUrlScrapingJob = perfumeUrlRepository.save(PerfumeUrlScrapingJob(url = perfumeUrl))
+        val perfumeUrlScrapingJob = perfumeUrlRepository.save(PerfumeUrlScrapingJob(url))
         return Pair(true, perfumeUrlScrapingJob)
     }
 }


### PR DESCRIPTION
- business 로직에서 사용하는 datasource, spring batch metadata 용도로 사용하는 datasource 를 분리하려고했으나, business 데이터도 배치 스키마에 저장되는 이슈가 있어서 business, metadata 모두 한 스키마에서 관리하도록 변경