### PR TITLE
feat: 향수, 브랜드 검색 API 추가

### DIFF
--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/brand/BrandController.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/brand/BrandController.kt
@@ -1,0 +1,18 @@
+package mashup.backend.spring.acm.presentation.api.brand
+
+import mashup.backend.spring.acm.presentation.ApiResponse
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/brands")
+class BrandController {
+    @PostMapping("/search")
+    fun search(
+        @RequestBody brandSearchRequest: BrandSearchRequest,
+    ): ApiResponse<BrandSearchResponse> {
+        TODO()
+    }
+}

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/brand/BrandData.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/brand/BrandData.kt
@@ -1,0 +1,14 @@
+package mashup.backend.spring.acm.presentation.api.brand
+
+data class BrandSearchRequest(
+    val name: String,
+)
+
+data class BrandSearchResponse(
+    val brands: List<BrandSimpleResponse>,
+)
+
+data class BrandSimpleResponse(
+    val id: Long,
+    val name: String,
+)

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/perfume/PerfumeController.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/perfume/PerfumeController.kt
@@ -3,10 +3,7 @@ package mashup.backend.spring.acm.presentation.api.perfume
 import io.swagger.annotations.ApiOperation
 import mashup.backend.spring.acm.domain.perfume.PerfumeService
 import mashup.backend.spring.acm.presentation.ApiResponse
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RequestMapping("/api/v1/perfumes")
 @RestController
@@ -18,5 +15,12 @@ class PerfumeController(val perfumeService: PerfumeService) {
         val similarPerfumes = SimpleSimilarPerfume.of(perfumeService.getSimilarPerfume(id))
 
         return ApiResponse.success(PerfumeDetailResponse(PerfumeDetail.of(perfumes, similarPerfumes)))
+    }
+
+    @PostMapping("/search")
+    fun search(
+        @RequestBody perfumeSearchRequest: PerfumeSearchRequest,
+    ): ApiResponse<PerfumeSearchResponse> {
+        TODO()
     }
 }

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/perfume/PerfumeData.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/perfume/PerfumeData.kt
@@ -89,3 +89,16 @@ data class SimplePerfumeNote(
         )
     }
 }
+
+data class PerfumeSearchRequest(
+    val name: String,
+)
+
+data class PerfumeSearchResponse(
+    val perfumes: List<PerfumeSimpleResponse>,
+)
+
+data class PerfumeSimpleResponse(
+    val id: Long,
+    val name: String,
+)


### PR DESCRIPTION
- 문서에 노출하기 위해 검색 API 의 controller 먼저 추가합니다 (#32)
- `POST /api/v1/perfumes/search`
- `POST /api/v1/brands/search`