### PR TITLE
닉네임 수정 API 추가

### DIFF
--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/application/member/MemberApplicationService.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/application/member/MemberApplicationService.kt
@@ -8,6 +8,7 @@ import mashup.backend.spring.acm.domain.member.MemberService
 
 interface MemberApplicationService {
     fun getMemberInfo(memberId: Long): MemberDetailVo
+    fun updateNickname(memberId: Long, nickname: String)
     fun initialize(memberId: Long, requestVo: MemberInitializeRequestVo)
 }
 
@@ -22,6 +23,16 @@ class MemberApplicationServiceImpl(
      */
     override fun getMemberInfo(memberId: Long): MemberDetailVo {
         return memberService.findDetailById(memberId = memberId) ?: throw MemberNotFoundException(memberId = memberId)
+    }
+
+    /**
+     * 닉네임 수정
+     */
+    override fun updateNickname(memberId: Long, nickname: String) {
+        return memberService.updateNickname(
+            memberId = memberId,
+            nickname = nickname
+        )
     }
 
     /**

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberController.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberController.kt
@@ -50,13 +50,19 @@ class MemberController(
      * 닉네임 변경
      * - 200, SUCCESS
      * - 400, MEMBER_NICKNAME_ALREADY_EXIST
+     * - 400, MEMBER_NOT_FOUND
      * - 401, UNAUTHORIZED
      */
     @PutMapping("/me/nickname")
     fun updateNickname(
         @ApiIgnore @ModelAttribute("memberId") memberId: Long,
+        @RequestBody nicknameUpdateRequest: NicknameUpdateRequest
     ): ApiResponse<Unit> {
-        TODO()
+        memberApplicationService.updateNickname(
+            memberId = memberId,
+            nickname = nicknameUpdateRequest.nickname
+        )
+        return ApiResponse.success()
     }
 
     /**

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberController.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberController.kt
@@ -47,6 +47,19 @@ class MemberController(
     }
 
     /**
+     * 닉네임 변경
+     * - 200, SUCCESS
+     * - 400, MEMBER_NICKNAME_ALREADY_EXIST
+     * - 401, UNAUTHORIZED
+     */
+    @PutMapping("/me/nickname")
+    fun updateNickname(
+        @ApiIgnore @ModelAttribute("memberId") memberId: Long,
+    ): ApiResponse<Unit> {
+        TODO()
+    }
+
+    /**
      * 회원 초기화 (온보딩 정보 입력, 상태 변경(ASSOCIATE -> ACTIVE))
      * - 200, SUCCESS
      * - 400, MEMBER_STATUS_ALREADY_ACTIVE

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberData.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberData.kt
@@ -37,11 +37,14 @@ data class LoginRequest(
     val idProviderUserId: String
 )
 
-
 data class MemberInitializeRequest(
     val name: String?,
     val gender: String?,
     val ageGroup: String?,
     val noteGroupIds: List<Long>?,
     val perfumeIds: List<Long>?
+)
+
+data class NicknameUpdateRequest(
+    val nickname: String,
 )

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/ResultCode.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/ResultCode.kt
@@ -10,8 +10,9 @@ enum class ResultCode(val message: String = "") {
 
     // member
     MEMBER_NOT_FOUND("회원 조회 실패"),
-    MEMBER_STATUS_ALREADY_ACTIVE("이미 초기화된 회원입니다."),
-    MEMBER_NICKNAME_ALREADY_EXIST("이미 사용중인 닉네임입니다."),
+    MEMBER_STATUS_ALREADY_ACTIVE("이미 초기화된 회원입니다"),
+    MEMBER_NICKNAME_ALREADY_EXIST("이미 사용중인 닉네임입니다"),
+    MEMBER_NICKNAME_INVALID("사용할 수 없는 닉네임입니다"),
     // note
     NOTE_NOT_FOUND("노트 조회 실패"),
     NOTE_ALREADY_EXIST("노트 중복"),

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/ResultCode.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/ResultCode.kt
@@ -11,6 +11,7 @@ enum class ResultCode(val message: String = "") {
     // member
     MEMBER_NOT_FOUND("회원 조회 실패"),
     MEMBER_STATUS_ALREADY_ACTIVE("이미 초기화된 회원입니다."),
+    MEMBER_NICKNAME_ALREADY_EXIST("이미 사용중인 닉네임입니다."),
     // note
     NOTE_NOT_FOUND("노트 조회 실패"),
     NOTE_ALREADY_EXIST("노트 중복"),

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/exception/MemberNicknameDuplicatedException.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/exception/MemberNicknameDuplicatedException.kt
@@ -1,0 +1,17 @@
+package mashup.backend.spring.acm.domain.exception
+
+import mashup.backend.spring.acm.domain.ResultCode
+
+class MemberNicknameDuplicatedException(
+    override val message: String?,
+    override val cause: Throwable?,
+): BusinessException(
+    resultCode = ResultCode.MEMBER_NICKNAME_ALREADY_EXIST,
+    message = message,
+    cause = cause
+) {
+    constructor(nickname: String) : this(
+        message = "${ResultCode.MEMBER_NICKNAME_ALREADY_EXIST.message}. nickname:$nickname",
+        cause = null,
+    )
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/exception/MemberNicknameInvalidException.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/exception/MemberNicknameInvalidException.kt
@@ -1,0 +1,17 @@
+package mashup.backend.spring.acm.domain.exception
+
+import mashup.backend.spring.acm.domain.ResultCode
+
+class MemberNicknameInvalidException(
+    override val message: String?,
+    override val cause: Throwable?,
+) : BadRequestException(
+    resultCode = ResultCode.MEMBER_NICKNAME_INVALID,
+    message = message,
+    cause = cause,
+) {
+    constructor(nickname: String): this(
+        message = "${ResultCode.MEMBER_NICKNAME_INVALID.message}. nickname:$nickname",
+        cause = null,
+    )
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/Member.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/Member.kt
@@ -19,6 +19,10 @@ class Member(
         memberIdProviders.add(memberIdProvider)
     }
 
+    fun updateNickname(nickname: String) {
+        memberDetail.name = nickname
+    }
+
     fun initialize(memberInitializeRequestVo: MemberInitializeRequestVo) {
         if (memberStatus == MemberStatus.ACTIVE) {
             throw MemberInitializeFailedException("이미 ACTIVE 상태인 회원입니다. memberId: $id")
@@ -48,5 +52,4 @@ class Member(
     override fun toString(): String {
         return "Member(memberStatus=$memberStatus, memberDetail=$memberDetail)"
     }
-
 }

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberRepository.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface MemberRepository: JpaRepository<Member, Long> {
     fun findByMemberIdProviders_IdProviderInfo(idProviderInfo: IdProviderInfo): Member?
     fun findByIdAndMemberStatus(memberId: Long, memberStatus: MemberStatus): Member?
+    fun existsByMemberDetail_name(name: String): Boolean
 }

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberService.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberService.kt
@@ -1,8 +1,10 @@
 package mashup.backend.spring.acm.domain.member
 
+import mashup.backend.spring.acm.domain.exception.MemberNicknameDuplicatedException
+import mashup.backend.spring.acm.domain.exception.MemberNicknameInvalidException
+import mashup.backend.spring.acm.domain.exception.MemberNotFoundException
 import mashup.backend.spring.acm.domain.member.idprovider.IdProviderInfo
 import mashup.backend.spring.acm.domain.member.idprovider.MemberIdProvider
-import mashup.backend.spring.acm.domain.exception.MemberNotFoundException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,13 +15,14 @@ interface MemberService {
     fun findDetailById(memberId: Long): MemberDetailVo?
     fun join(idProviderInfo: IdProviderInfo): MemberDetailVo
     fun withdraw()
+    fun updateNickname(memberId: Long, nickname: String)
     fun initialize(memberId: Long, requestVo: MemberInitializeRequestVo)
 }
 
 @Service
 @Transactional(readOnly = true)
 class MemberServiceImpl(
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
 ) : MemberService {
     override fun findById(memberId: Long): Member? {
         return memberRepository.findByIdOrNull(memberId)
@@ -57,6 +60,35 @@ class MemberServiceImpl(
     @Transactional
     override fun withdraw() {
         TODO("Not yet implemented")
+    }
+
+    /**
+     * 닉네임 수정
+     */
+    @Transactional
+    override fun updateNickname(memberId: Long, nickname: String) {
+        val member = memberRepository.findByIdOrNull(memberId)
+            ?: throw MemberNotFoundException(memberId = memberId)
+        if (member.memberDetail.name == nickname) {
+            return
+        }
+        validateNickname(nickname)
+        member.updateNickname(nickname)
+    }
+
+    /**
+     * 닉네임 검증
+     */
+    private fun validateNickname(nickname: String) {
+        if (memberRepository.existsByMemberDetail_name(name = nickname)) {
+            throw MemberNicknameDuplicatedException(nickname = nickname)
+        }
+        if (nickname.isBlank()) {
+            throw MemberNicknameInvalidException(nickname = nickname)
+        }
+        if (nickname.length > 50) {
+            throw MemberNicknameInvalidException(nickname = nickname)
+        }
     }
 
     @Transactional


### PR DESCRIPTION
resolve #70 
- `PUT /api/v1/members/me/nickname`
- 50자 이하
- 공백아닌 문자 포함해야함
- 중복금지 (대소문자만 다른 경우 중복으로 판단)

### Response
- `200 SUCCESS`
- `400 MEMBER_NICKNAME_INVALID` : 50자 초과하는 경우, 글자 없이 빈칸만으로 이루어진 경우,
- `400 MEMBER_NOT_FOUND` : id 로 회원 조회 실패한 경우