### PR TITLE
toString 메서드에서 긴 문자열은 일부분만 출력

### DIFF
--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/Note.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/Note.kt
@@ -30,7 +30,6 @@ class Note(
         other as Note
 
         if (name != other.name) return false
-        if (description != other.description) return false
         if (url != other.url) return false
         if (thumbnailImageUrl != other.thumbnailImageUrl) return false
 
@@ -39,13 +38,12 @@ class Note(
 
     override fun hashCode(): Int {
         var result = name.hashCode()
-        result = 31 * result + description.hashCode()
         result = 31 * result + url.hashCode()
         result = 31 * result + thumbnailImageUrl.hashCode()
         return result
     }
 
     override fun toString(): String {
-        return "Note(name='$name', description='$description', url='$url', thumbnailImageUrl='$thumbnailImageUrl', noteGroup=$noteGroup)"
+        return "Note(name='$name', description='${description.take(30)}', url='$url', thumbnailImageUrl='$thumbnailImageUrl', noteGroup=$noteGroup)"
     }
 }

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroup.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroup.kt
@@ -46,10 +46,8 @@ class NoteGroup(
         other as NoteGroup
 
         if (name != other.name) return false
-        if (description != other.description) return false
         if (imageUrl != other.imageUrl) return false
         if (originalName != other.originalName) return false
-        if (originalDescription != other.originalDescription) return false
         if (originalImageUrl != other.originalImageUrl) return false
 
         return true
@@ -57,15 +55,13 @@ class NoteGroup(
 
     override fun hashCode(): Int {
         var result = name.hashCode()
-        result = 31 * result + description.hashCode()
         result = 31 * result + imageUrl.hashCode()
         result = 31 * result + originalName.hashCode()
-        result = 31 * result + originalDescription.hashCode()
         result = 31 * result + originalImageUrl.hashCode()
         return result
     }
 
     override fun toString(): String {
-        return "NoteGroup(name='$name', description='$description', imageUrl='$imageUrl', originalName='$originalName', originalDescription='$originalDescription', originalImageUrl='$originalImageUrl')"
+        return "NoteGroup(name='$name', description='${description.take(30)}', imageUrl='$imageUrl', originalName='$originalName', originalDescription='$${originalDescription.take(30)}', originalImageUrl='$originalImageUrl')"
     }
 }


### PR DESCRIPTION
resolve #61 
- 가독성을 위해 description 은 일부분만 출력하고 뒷부분 생략
- 성능을 위해 equals, hashcode 에서 description 은 제외