### PR TITLE
요청이 잘못된 경우 400 상태코드로 응답합니다

### DIFF
--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/application/login/LoginApplicationService.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/application/login/LoginApplicationService.kt
@@ -19,7 +19,7 @@ class LoginApplicationServiceImpl(
         val memberDetailVo = memberService.join(
             idProviderInfo = IdProviderInfo(
                 idProviderType = loginRequestVo.idProviderType,
-                idProviderUserId = loginRequestVo.idProviderUserId
+                idProviderUserId = loginRequestVo.idProviderUserId.trim()
             )
         )
         return LoginResponseVo(

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/ApiControllerAdvice.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/ApiControllerAdvice.kt
@@ -8,6 +8,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -23,6 +24,19 @@ class ApiControllerAdvice {
             return principal.principal.toString().toLong()
         }
         return null
+    }
+
+    /**
+     * 요청에 오류가 있는 경우
+     */
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ApiResponse<Unit> {
+        log.error("MethodArgumentNotValidException", e)
+        return ApiResponse.failure(
+            message = e.message ?: ResultCode.BAD_REQUEST.message,
+            code = ResultCode.BAD_REQUEST.name,
+        )
     }
 
     /**

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberController.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberController.kt
@@ -1,16 +1,14 @@
 package mashup.backend.spring.acm.presentation.api.member
 
 import mashup.backend.spring.acm.application.LoginApplicationService
-import mashup.backend.spring.acm.application.login.toLoginResponse
-import mashup.backend.spring.acm.application.login.toVo
+import mashup.backend.spring.acm.presentation.assembler.toLoginResponse
+import mashup.backend.spring.acm.presentation.assembler.toVo
 import mashup.backend.spring.acm.application.member.MemberApplicationService
 import mashup.backend.spring.acm.presentation.ApiResponse
 import mashup.backend.spring.acm.presentation.assembler.toMemberInfoResponse
-import mashup.backend.spring.acm.presentation.assembler.toVo
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.*
 import springfox.documentation.annotations.ApiIgnore
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/api/v1/members")
@@ -24,7 +22,7 @@ class MemberController(
      */
     @PostMapping("/login")
     fun login(
-        @RequestBody loginRequest: LoginRequest,
+        @RequestBody @Valid loginRequest: LoginRequest,
     ): ApiResponse<LoginResponse> {
         return ApiResponse.success(
             data = loginApplicationService.login(loginRequestVo = loginRequest.toVo()).toLoginResponse()

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberData.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberData.kt
@@ -1,9 +1,12 @@
 package mashup.backend.spring.acm.presentation.api.member
 
 import mashup.backend.spring.acm.domain.member.idprovider.IdProviderType
+import org.hibernate.validator.constraints.Length
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
 
 data class MemberInfoResponse(
-    val member: MemberDetailResponse
+    val member: MemberDetailResponse,
 )
 
 data class MemberDetailResponse(
@@ -24,17 +27,20 @@ data class MemberDetailResponse(
     /**
      * 나이대
      */
-    val ageGroup: String?
+    val ageGroup: String?,
 )
 
 data class LoginResponse(
     val accessToken: String,
-    val member: MemberDetailResponse
+    val member: MemberDetailResponse,
 )
 
 data class LoginRequest(
-    val idProviderType: IdProviderType,
-    val idProviderUserId: String
+    @field:NotNull
+    val idProviderType: IdProviderType?,
+    @field:NotBlank
+    @field:Length(max = 255)
+    val idProviderUserId: String?,
 )
 
 
@@ -43,5 +49,5 @@ data class MemberInitializeRequest(
     val gender: String?,
     val ageGroup: String?,
     val noteGroupIds: List<Long>?,
-    val perfumeIds: List<Long>?
+    val perfumeIds: List<Long>?,
 )

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/assembler/LoginExtentions.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/assembler/LoginExtentions.kt
@@ -1,12 +1,14 @@
-package mashup.backend.spring.acm.application.login
+package mashup.backend.spring.acm.presentation.assembler
 
+import mashup.backend.spring.acm.application.login.LoginRequestVo
+import mashup.backend.spring.acm.application.login.LoginResponseVo
 import mashup.backend.spring.acm.presentation.api.member.LoginRequest
 import mashup.backend.spring.acm.presentation.api.member.LoginResponse
-import mashup.backend.spring.acm.presentation.assembler.toMemberDetailResponse
+import java.lang.IllegalArgumentException
 
 fun LoginRequest.toVo(): LoginRequestVo = LoginRequestVo(
-    idProviderType = this.idProviderType,
-    idProviderUserId = this.idProviderUserId
+    idProviderType = this.idProviderType ?: throw IllegalArgumentException("'idProviderType' must not be null"),
+    idProviderUserId = this.idProviderUserId ?: throw IllegalArgumentException("'idProviderUserId' must not be null")
 )
 
 fun LoginResponseVo.toLoginResponse(): LoginResponse {

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/ResultCode.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/ResultCode.kt
@@ -6,11 +6,12 @@ enum class ResultCode(val message: String = "") {
     UNAUTHORIZED("인증 실패"),
     FORBIDDEN("권한 없음"),
     // 기타
+    BAD_REQUEST("요청에 오류가 있습니다"),
     INTERNAL_SERVER_ERROR("서버 에러"),
 
     // member
     MEMBER_NOT_FOUND("회원 조회 실패"),
-    MEMBER_STATUS_ALREADY_ACTIVE("이미 초기화된 회원입니다."),
+    MEMBER_STATUS_ALREADY_ACTIVE("이미 초기화된 회원입니다"),
     // note
     NOTE_NOT_FOUND("노트 조회 실패"),
     NOTE_ALREADY_EXIST("노트 중복"),


### PR DESCRIPTION
resolve #71 
다음과 같이 API 요청 형식이나 값에 오류가 있는 경우, 응답 코드를 변경합니다

### AS-IS
`500 INTERNAL_SERVER_ERROR`
### TO-BE
`400 BAD_REQUEST`
- parameter 가 올바르지 않은 경우
- json parsing 실패 등
