### PR TITLE
노트 그룹 상세 조회 API 추가

### DIFF
--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/application/note/NoteApplicationService.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/application/note/NoteApplicationService.kt
@@ -1,6 +1,7 @@
 package mashup.backend.spring.acm.application.note
 
 import mashup.backend.spring.acm.application.ApplicationService
+import mashup.backend.spring.acm.domain.note.NoteGroupDetailVo
 import mashup.backend.spring.acm.domain.note.NoteGroupService
 import mashup.backend.spring.acm.domain.note.NoteGroupSimpleVo
 
@@ -9,4 +10,6 @@ class NoteApplicationService(
     private val noteGroupService: NoteGroupService,
 ) {
     fun getAllNoteGroups(): List<NoteGroupSimpleVo> = noteGroupService.findAll().map { NoteGroupSimpleVo(it) }
+
+    fun getNoteGroup(noteGroupId: Long): NoteGroupDetailVo = noteGroupService.getDetailById(noteGroupId)
 }

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteGroupController.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteGroupController.kt
@@ -4,6 +4,7 @@ import mashup.backend.spring.acm.application.note.NoteApplicationService
 import mashup.backend.spring.acm.presentation.ApiResponse
 import mashup.backend.spring.acm.presentation.assembler.toDto
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -27,6 +28,14 @@ class NoteGroupController(
     /**
      * 노트 그룹 상세 조회
      */
-    @GetMapping("/{noteGroupId")
-    fun getNoteGroup(): ApiResponse<NoteGroupDetailData> = TODO()
+    @GetMapping("/{noteGroupId}")
+    fun getNoteGroup(
+        @PathVariable noteGroupId: Long,
+    ): ApiResponse<NoteGroupDetailData> {
+        return ApiResponse.success(
+            data = NoteGroupDetailData(
+                noteGroup = noteApplicationService.getNoteGroup(noteGroupId = noteGroupId).toDto(),
+            ),
+        )
+    }
 }

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteGroupController.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteGroupController.kt
@@ -16,11 +16,17 @@ class NoteGroupController(
      * 노트 그룹 목록 조회
      */
     @GetMapping
-    fun getNoteGroupList(): ApiResponse<NoteGroupListResponse> {
+    fun getNoteGroupList(): ApiResponse<NoteGroupListData> {
         return ApiResponse.success(
-            data = NoteGroupListResponse(
+            data = NoteGroupListData(
                 noteGroups = noteApplicationService.getAllNoteGroups().map { it.toDto() }
             )
         )
     }
+
+    /**
+     * 노트 그룹 상세 조회
+     */
+    @GetMapping("/{noteGroupId")
+    fun getNoteGroup(): ApiResponse<NoteGroupDetailData> = TODO()
 }

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteGroupData.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteGroupData.kt
@@ -23,5 +23,6 @@ data class NoteGroupDetailResponse(
 data class NoteSimpleResponse(
     val id: Long,
     val name: String,
+    val description: String,
     val thumbnailImageUrl: String,
 )

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteGroupData.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteGroupData.kt
@@ -1,6 +1,6 @@
 package mashup.backend.spring.acm.presentation.api.note
 
-data class NoteGroupListResponse(
+data class NoteGroupListData(
     val noteGroups: List<NoteGroupSimpleResponse>,
 )
 
@@ -9,3 +9,19 @@ data class NoteGroupSimpleResponse(
     val name: String,
 )
 
+data class NoteGroupDetailData(
+    val noteGroup: NoteGroupDetailResponse
+)
+
+data class NoteGroupDetailResponse(
+    val id: Long,
+    val name: String,
+    val description: String,
+    val notes: List<NoteSimpleResponse>,
+)
+
+data class NoteSimpleResponse(
+    val id: Long,
+    val name: String,
+    val thumbnailImageUrl: String,
+)

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/assembler/NoteExtensions.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/assembler/NoteExtensions.kt
@@ -1,9 +1,27 @@
 package mashup.backend.spring.acm.presentation.assembler
 
+import mashup.backend.spring.acm.domain.note.NoteGroupDetailVo
 import mashup.backend.spring.acm.domain.note.NoteGroupSimpleVo
+import mashup.backend.spring.acm.domain.note.NoteSimpleVo
+import mashup.backend.spring.acm.presentation.api.note.NoteGroupDetailResponse
 import mashup.backend.spring.acm.presentation.api.note.NoteGroupSimpleResponse
+import mashup.backend.spring.acm.presentation.api.note.NoteSimpleResponse
 
 fun NoteGroupSimpleVo.toDto() = NoteGroupSimpleResponse(
     id = this.id,
     name = this.name,
+)
+
+fun NoteGroupDetailVo.toDto() = NoteGroupDetailResponse(
+    id = this.id,
+    name = this.name,
+    description = this.description,
+    notes = this.notes.map { it.toDto() }
+)
+
+fun NoteSimpleVo.toDto() = NoteSimpleResponse(
+    id = this.id,
+    name = this.name,
+    description = this.description,
+    thumbnailImageUrl = this.thumbnailImageUrl
 )

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/ResultCode.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/ResultCode.kt
@@ -17,6 +17,8 @@ enum class ResultCode(val message: String = "") {
     // note
     NOTE_NOT_FOUND("노트 조회 실패"),
     NOTE_ALREADY_EXIST("노트 중복"),
+    // note group
+    NOTE_GROUP_NOT_FOUND("노트 그룹 조회 실패"),
     // perfume
     PERFUME_NOT_FOUND("향수 조회 실패"),
     // brand

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/exception/NoteGroupNotFoundException.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/exception/NoteGroupNotFoundException.kt
@@ -1,0 +1,16 @@
+package mashup.backend.spring.acm.domain.exception
+
+import mashup.backend.spring.acm.domain.ResultCode
+
+class NoteGroupNotFoundException(
+    override val message: String? = null,
+    override val cause: Throwable? = null,
+) : NotFoundException(
+    resultCode = ResultCode.NOTE_GROUP_NOT_FOUND,
+    message = message,
+    cause = cause,
+) {
+    constructor(noteGroupId: Long) : this(
+        message = "노트 그룹을 찾을 수 없습니다. noteGroupId: $noteGroupId",
+    )
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/Note.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/Note.kt
@@ -2,6 +2,7 @@ package mashup.backend.spring.acm.domain.note
 
 import mashup.backend.spring.acm.domain.BaseEntity
 import javax.persistence.Entity
+import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 
 @Entity
@@ -11,6 +12,7 @@ class Note(
     val url: String,
     val thumbnailImageUrl: String,
     @ManyToOne
+    @JoinColumn
     var noteGroup: NoteGroup?
 ) : BaseEntity() {
     companion object {

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroup.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroup.kt
@@ -2,7 +2,6 @@ package mashup.backend.spring.acm.domain.note
 
 import mashup.backend.spring.acm.domain.BaseEntity
 import javax.persistence.Entity
-import javax.persistence.JoinColumn
 import javax.persistence.OneToMany
 
 /**
@@ -29,6 +28,8 @@ class NoteGroup(
     val originalName: String,
     val originalDescription: String,
     val originalImageUrl: String,
+    @OneToMany(mappedBy = "noteGroup")
+    val notes: List<Note> = ArrayList(),
 ) : BaseEntity() {
     companion object {
         fun from(noteGroupCreateVo: NoteGroupCreateVo): NoteGroup = NoteGroup(
@@ -37,7 +38,7 @@ class NoteGroup(
             imageUrl = noteGroupCreateVo.imageUrl,
             originalName = noteGroupCreateVo.name,
             originalDescription = noteGroupCreateVo.description,
-            originalImageUrl = noteGroupCreateVo.imageUrl
+            originalImageUrl = noteGroupCreateVo.imageUrl,
         )
     }
 
@@ -64,6 +65,8 @@ class NoteGroup(
     }
 
     override fun toString(): String {
-        return "NoteGroup(name='$name', description='${description.take(30)}', imageUrl='$imageUrl', originalName='$originalName', originalDescription='$${originalDescription.take(30)}', originalImageUrl='$originalImageUrl')"
+        return "NoteGroup(name='$name', description='${description.take(30)}', imageUrl='$imageUrl', originalName='$originalName', originalDescription='$${
+            originalDescription.take(30)
+        }', originalImageUrl='$originalImageUrl')"
     }
 }

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroup.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroup.kt
@@ -2,6 +2,8 @@ package mashup.backend.spring.acm.domain.note
 
 import mashup.backend.spring.acm.domain.BaseEntity
 import javax.persistence.Entity
+import javax.persistence.JoinColumn
+import javax.persistence.OneToMany
 
 /**
  * Note Groups:

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroupDetailVo.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroupDetailVo.kt
@@ -1,0 +1,15 @@
+package mashup.backend.spring.acm.domain.note
+
+data class NoteGroupDetailVo(
+    val id: Long,
+    val name: String,
+    val description: String,
+    val notes: List<NoteSimpleVo>,
+) {
+    constructor(noteGroup: NoteGroup) : this(
+        id = noteGroup.id,
+        name = noteGroup.name,
+        description = noteGroup.description,
+        notes = noteGroup.notes.map { NoteSimpleVo(it) }
+    )
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroupService.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroupService.kt
@@ -1,5 +1,7 @@
 package mashup.backend.spring.acm.domain.note
 
+import mashup.backend.spring.acm.domain.exception.NoteGroupNotFoundException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -7,13 +9,14 @@ interface NoteGroupService {
     fun create(noteGroupCreateVo: NoteGroupCreateVo): NoteGroup
     fun getNoteGroupByName(originalName: String): NoteGroup?
     fun findAll(): List<NoteGroup>
+    fun getDetailById(noteGroupId: Long): NoteGroupDetailVo
 }
 
 @Service
 @Transactional(readOnly = true)
 class NoteGroupServiceImpl(
     private val noteGroupRepository: NoteGroupRepository,
-): NoteGroupService {
+) : NoteGroupService {
     @Transactional(readOnly = false)
     override fun create(noteGroupCreateVo: NoteGroupCreateVo): NoteGroup {
         if (noteGroupRepository.existsByOriginalName(noteGroupCreateVo.name)) {
@@ -22,7 +25,12 @@ class NoteGroupServiceImpl(
         return noteGroupRepository.save(NoteGroup.from(noteGroupCreateVo))
     }
 
-    override fun getNoteGroupByName(originalName: String): NoteGroup? = noteGroupRepository.findByOriginalName(originalName)
+    override fun getNoteGroupByName(originalName: String): NoteGroup? =
+        noteGroupRepository.findByOriginalName(originalName)
 
     override fun findAll(): List<NoteGroup> = noteGroupRepository.findAll()
+
+    override fun getDetailById(noteGroupId: Long): NoteGroupDetailVo = noteGroupRepository.findByIdOrNull(noteGroupId)
+        ?.let { NoteGroupDetailVo(it) }
+        ?: throw NoteGroupNotFoundException(noteGroupId = noteGroupId)
 }

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteSimpleVo.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteSimpleVo.kt
@@ -1,0 +1,15 @@
+package mashup.backend.spring.acm.domain.note
+
+data class NoteSimpleVo(
+    val id: Long,
+    val name: String,
+    val description: String,
+    val thumbnailImageUrl: String,
+) {
+    constructor(note: Note) : this(
+        id = note.id,
+        name = note.name,
+        description = note.description,
+        thumbnailImageUrl = note.thumbnailImageUrl,
+    )
+}


### PR DESCRIPTION
resolve #79 

- `GET /api/v1/note-groups/{note-group-Id}`

```
Hibernate: 
    select
        notegroup0_.id as id1_8_0_,
        notegroup0_.created_at as created_2_8_0_,
        notegroup0_.updated_at as updated_3_8_0_,
        notegroup0_.description as descript4_8_0_,
        notegroup0_.image_url as image_ur5_8_0_,
        notegroup0_.name as name6_8_0_,
        notegroup0_.original_description as original7_8_0_,
        notegroup0_.original_image_url as original8_8_0_,
        notegroup0_.original_name as original9_8_0_ 
    from
        note_group notegroup0_ 
    where
        notegroup0_.id=?
Hibernate: 
    select
        notes0_.note_group_id as note_gro8_7_0_,
        notes0_.id as id1_7_0_,
        notes0_.id as id1_7_1_,
        notes0_.created_at as created_2_7_1_,
        notes0_.updated_at as updated_3_7_1_,
        notes0_.description as descript4_7_1_,
        notes0_.name as name5_7_1_,
        notes0_.note_group_id as note_gro8_7_1_,
        notes0_.thumbnail_image_url as thumbnai6_7_1_,
        notes0_.url as url7_7_1_ 
    from
        note notes0_ 
    where
        notes0_.note_group_id=?
```