### PR TITLE
노트 상세 조회 API 추가

### DIFF
--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/application/note/NoteApplicationService.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/application/note/NoteApplicationService.kt
@@ -1,15 +1,13 @@
 package mashup.backend.spring.acm.application.note
 
 import mashup.backend.spring.acm.application.ApplicationService
-import mashup.backend.spring.acm.domain.note.NoteGroupDetailVo
-import mashup.backend.spring.acm.domain.note.NoteGroupService
-import mashup.backend.spring.acm.domain.note.NoteGroupSimpleVo
+import mashup.backend.spring.acm.domain.note.NoteService
+import mashup.backend.spring.acm.presentation.api.note.NoteDetailResponse
+import mashup.backend.spring.acm.presentation.assembler.toDto
 
 @ApplicationService
 class NoteApplicationService(
-    private val noteGroupService: NoteGroupService,
+    private val noteService: NoteService,
 ) {
-    fun getAllNoteGroups(): List<NoteGroupSimpleVo> = noteGroupService.findAll().map { NoteGroupSimpleVo(it) }
-
-    fun getNoteGroup(noteGroupId: Long): NoteGroupDetailVo = noteGroupService.getDetailById(noteGroupId)
+    fun getNote(noteId: Long): NoteDetailResponse = noteService.getNoteDetail(noteId = noteId).toDto()
 }

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/application/note/NoteGroupApplicationService.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/application/note/NoteGroupApplicationService.kt
@@ -1,0 +1,15 @@
+package mashup.backend.spring.acm.application.note
+
+import mashup.backend.spring.acm.application.ApplicationService
+import mashup.backend.spring.acm.domain.note.NoteGroupDetailVo
+import mashup.backend.spring.acm.domain.note.NoteGroupService
+import mashup.backend.spring.acm.domain.note.NoteGroupSimpleVo
+
+@ApplicationService
+class NoteGroupApplicationService(
+    private val noteGroupService: NoteGroupService,
+) {
+    fun getAllNoteGroups(): List<NoteGroupSimpleVo> = noteGroupService.findAll().map { NoteGroupSimpleVo(it) }
+
+    fun getNoteGroup(noteGroupId: Long): NoteGroupDetailVo = noteGroupService.getDetailById(noteGroupId)
+}

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteController.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteController.kt
@@ -1,5 +1,6 @@
 package mashup.backend.spring.acm.presentation.api.note
 
+import mashup.backend.spring.acm.application.note.NoteApplicationService
 import mashup.backend.spring.acm.presentation.ApiResponse
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -7,7 +8,18 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/notes")
-class NoteController {
+class NoteController(
+    private val noteApplicationService: NoteApplicationService,
+) {
+    /**
+     * 노트 상세 조회
+     */
     @GetMapping("/{noteId}")
-    fun getNoteDetail(noteId: Long): ApiResponse<NoteDetailData> = TODO()
+    fun getNoteDetail(noteId: Long): ApiResponse<NoteDetailData> {
+        return ApiResponse.success(
+            data = NoteDetailData(
+                note = noteApplicationService.getNote(noteId = noteId),
+            ),
+        )
+    }
 }

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteController.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteController.kt
@@ -1,0 +1,13 @@
+package mashup.backend.spring.acm.presentation.api.note
+
+import mashup.backend.spring.acm.presentation.ApiResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/notes")
+class NoteController {
+    @GetMapping("/{noteId}")
+    fun getNoteDetail(noteId: Long): ApiResponse<NoteDetailData> = TODO()
+}

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteData.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteData.kt
@@ -10,13 +10,14 @@ data class NoteDetailResponse(
     val id: Long,
     val name: String,
     val description: String,
-    val url: String,
     val thumbnailImageUrl: String,
-    val noteGroup: NoteGroupSimpleResponse,
+    val noteGroup: NoteGroupSimpleResponse?,
     val perfumes: List<PerfumeSimpleResponse>,
 )
 
-data class NoteGroupSimpleResponse(
+data class NoteSimpleResponse(
     val id: Long,
     val name: String,
+    val description: String,
+    val thumbnailImageUrl: String,
 )

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteData.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteData.kt
@@ -1,0 +1,22 @@
+package mashup.backend.spring.acm.presentation.api.note
+
+import mashup.backend.spring.acm.presentation.api.perfume.PerfumeSimpleResponse
+
+data class NoteDetailData(
+    val note: NoteDetailResponse,
+)
+
+data class NoteDetailResponse(
+    val id: Long,
+    val name: String,
+    val description: String,
+    val url: String,
+    val thumbnailImageUrl: String,
+    val noteGroup: NoteGroupSimpleResponse,
+    val perfumes: List<PerfumeSimpleResponse>,
+)
+
+data class NoteGroupSimpleResponse(
+    val id: Long,
+    val name: String,
+)

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteGroupController.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteGroupController.kt
@@ -1,6 +1,6 @@
 package mashup.backend.spring.acm.presentation.api.note
 
-import mashup.backend.spring.acm.application.note.NoteApplicationService
+import mashup.backend.spring.acm.application.note.NoteGroupApplicationService
 import mashup.backend.spring.acm.presentation.ApiResponse
 import mashup.backend.spring.acm.presentation.assembler.toDto
 import org.springframework.web.bind.annotation.GetMapping
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/note-groups")
 class NoteGroupController(
-    private val noteApplicationService: NoteApplicationService,
+    private val noteGroupApplicationService: NoteGroupApplicationService,
 ) {
     /**
      * 노트 그룹 목록 조회
@@ -20,7 +20,7 @@ class NoteGroupController(
     fun getNoteGroupList(): ApiResponse<NoteGroupListData> {
         return ApiResponse.success(
             data = NoteGroupListData(
-                noteGroups = noteApplicationService.getAllNoteGroups().map { it.toDto() }
+                noteGroups = noteGroupApplicationService.getAllNoteGroups().map { it.toDto() }
             )
         )
     }
@@ -34,7 +34,7 @@ class NoteGroupController(
     ): ApiResponse<NoteGroupDetailData> {
         return ApiResponse.success(
             data = NoteGroupDetailData(
-                noteGroup = noteApplicationService.getNoteGroup(noteGroupId = noteGroupId).toDto(),
+                noteGroup = noteGroupApplicationService.getNoteGroup(noteGroupId = noteGroupId).toDto(),
             ),
         )
     }

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteGroupData.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/note/NoteGroupData.kt
@@ -19,10 +19,3 @@ data class NoteGroupDetailResponse(
     val description: String,
     val notes: List<NoteSimpleResponse>,
 )
-
-data class NoteSimpleResponse(
-    val id: Long,
-    val name: String,
-    val description: String,
-    val thumbnailImageUrl: String,
-)

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/assembler/NoteExtensions.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/assembler/NoteExtensions.kt
@@ -1,8 +1,10 @@
 package mashup.backend.spring.acm.presentation.assembler
 
+import mashup.backend.spring.acm.domain.note.NoteDetailVo
 import mashup.backend.spring.acm.domain.note.NoteGroupDetailVo
 import mashup.backend.spring.acm.domain.note.NoteGroupSimpleVo
 import mashup.backend.spring.acm.domain.note.NoteSimpleVo
+import mashup.backend.spring.acm.presentation.api.note.NoteDetailResponse
 import mashup.backend.spring.acm.presentation.api.note.NoteGroupDetailResponse
 import mashup.backend.spring.acm.presentation.api.note.NoteGroupSimpleResponse
 import mashup.backend.spring.acm.presentation.api.note.NoteSimpleResponse
@@ -24,4 +26,13 @@ fun NoteSimpleVo.toDto() = NoteSimpleResponse(
     name = this.name,
     description = this.description,
     thumbnailImageUrl = this.thumbnailImageUrl
+)
+
+fun NoteDetailVo.toDto() = NoteDetailResponse(
+    id = this.id,
+    name = this.name,
+    description = this.description,
+    thumbnailImageUrl = this.thumbnailImageUrl,
+    noteGroup = this.noteGroup?.toDto(),
+    perfumes = emptyList(),
 )

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/exception/NoteNotFoundException.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/exception/NoteNotFoundException.kt
@@ -9,4 +9,8 @@ class NoteNotFoundException(
     resultCode = ResultCode.NOTE_NOT_FOUND,
     message = message,
     cause = cause
-)
+) {
+    constructor(noteId: Long) : this(
+        message = "노트를 찾을 수 없습니다. noteId: $noteId",
+    )
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteDetailVo.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteDetailVo.kt
@@ -1,0 +1,17 @@
+package mashup.backend.spring.acm.domain.note
+
+data class NoteDetailVo(
+    val id: Long,
+    val name: String,
+    var description: String,
+    val thumbnailImageUrl: String,
+    var noteGroup: NoteGroupSimpleVo?,
+) {
+    constructor(note: Note) : this(
+        id = note.id,
+        name = note.name,
+        description = note.description,
+        thumbnailImageUrl = note.thumbnailImageUrl,
+        noteGroup = note.noteGroup?.let { NoteGroupSimpleVo(it) }
+    )
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteService.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteService.kt
@@ -12,6 +12,7 @@ interface NoteService {
     fun getNotes(pageable: Pageable): Page<Note>
     fun getNote(url: String): Note
     fun getFirstNoteToScrap(): Note?
+    fun getNoteDetail(noteId: Long): NoteDetailVo
     fun create(noteCreateVo: NoteCreateVo): Note
     fun update(noteId: Long, noteUpdateVo: NoteUpdateVo): Note
 }
@@ -27,6 +28,10 @@ class NoteServiceImpl(
     override fun getNote(url: String): Note = noteRepository.findByUrl(url) ?: throw NoteNotFoundException()
 
     override fun getFirstNoteToScrap(): Note? = noteRepository.findFirstByNoteGroupIsNull()
+
+    override fun getNoteDetail(noteId: Long): NoteDetailVo = noteRepository.findByIdOrNull(noteId)
+        ?.let { NoteDetailVo(it) }
+        ?: throw NoteNotFoundException(noteId = noteId)
 
     @Transactional
     override fun create(noteCreateVo: NoteCreateVo): Note {

--- a/acm-domain/src/main/resources/application-local.yml
+++ b/acm-domain/src/main/resources/application-local.yml
@@ -7,5 +7,9 @@ spring:
     hibernate:
       ddl-auto: update
       database-platform: org.hibernate.dialect.MySQL8Dialect
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
   main:
     allow-bean-definition-overriding: true


### PR DESCRIPTION
resolve #81 
- `GET /api/v1/notes/{note-id}`
```
select
        note0_.id as id1_7_0_,
        note0_.created_at as created_2_7_0_,
        note0_.updated_at as updated_3_7_0_,
        note0_.description as descript4_7_0_,
        note0_.name as name5_7_0_,
        note0_.note_group_id as note_gro8_7_0_,
        note0_.thumbnail_image_url as thumbnai6_7_0_,
        note0_.url as url7_7_0_,
        notegroup1_.id as id1_8_1_,
        notegroup1_.created_at as created_2_8_1_,
        notegroup1_.updated_at as updated_3_8_1_,
        notegroup1_.description as descript4_8_1_,
        notegroup1_.image_url as image_ur5_8_1_,
        notegroup1_.name as name6_8_1_,
        notegroup1_.original_description as original7_8_1_,
        notegroup1_.original_image_url as original8_8_1_,
        notegroup1_.original_name as original9_8_1_ 
    from
        note note0_ 
    left outer join
        note_group notegroup1_ 
            on note0_.note_group_id=notegroup1_.id 
    where
        note0_.id=?
```