### PR TITLE
refactor: 회원, 향수 gender class 분리

### DIFF
--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberData.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberData.kt
@@ -1,5 +1,6 @@
 package mashup.backend.spring.acm.presentation.api.member
 
+import mashup.backend.spring.acm.domain.member.MemberGender
 import mashup.backend.spring.acm.domain.member.idprovider.IdProviderType
 import org.hibernate.validator.constraints.Length
 import javax.validation.constraints.NotBlank

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/assembler/MemberExtentions.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/assembler/MemberExtentions.kt
@@ -2,6 +2,7 @@ package mashup.backend.spring.acm.presentation.assembler
 
 import mashup.backend.spring.acm.domain.member.AgeGroup
 import mashup.backend.spring.acm.domain.member.MemberDetailVo
+import mashup.backend.spring.acm.domain.member.MemberGender
 import mashup.backend.spring.acm.domain.member.MemberInitializeRequestVo
 import mashup.backend.spring.acm.domain.perfume.Gender
 import mashup.backend.spring.acm.presentation.api.member.MemberDetailResponse
@@ -22,7 +23,7 @@ fun MemberDetailVo.toMemberInfoResponse(): MemberInfoResponse = MemberInfoRespon
 
 fun MemberInitializeRequest.toVo(): MemberInitializeRequestVo {
     return MemberInitializeRequestVo(
-        gender = this.gender?.let { Gender.valueOf(it) } ?: Gender.UNKNOWN,
+        gender = this.gender?.let { MemberGender.valueOf(it) } ?: MemberGender.UNKNOWN,
         ageGroup = this.ageGroup?.let { AgeGroup.valueOf(it) } ?: AgeGroup.UNKNOWN,
         noteGroupIds = this.noteGroupIds,
     )

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberDetail.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberDetail.kt
@@ -16,7 +16,7 @@ class MemberDetail(
      * 성별
      */
     @Enumerated(EnumType.STRING)
-    var gender: Gender,
+    var gender: MemberGender,
     /**
      * 나이대 (10대, 20대, ...)
      */
@@ -32,7 +32,7 @@ class MemberDetail(
         fun empty(): MemberDetail {
             return MemberDetail(
                 name = "",
-                gender = Gender.UNKNOWN,
+                gender = MemberGender.UNKNOWN,
                 ageGroup = AgeGroup.UNKNOWN,
                 noteGroupIds = emptyList(),
             )

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberDetailVo.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberDetailVo.kt
@@ -1,12 +1,10 @@
 package mashup.backend.spring.acm.domain.member
 
-import mashup.backend.spring.acm.domain.perfume.Gender
-
 data class MemberDetailVo(
     val id: Long,
     val status: MemberStatus,
     val name: String?,
-    val gender: Gender?,
+    val gender: MemberGender?,
     val ageGroup: AgeGroup?,
 ) {
     constructor(member: Member) : this(

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberGender.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberGender.kt
@@ -1,0 +1,10 @@
+package mashup.backend.spring.acm.domain.member
+
+enum class MemberGender(
+    private val description: String,
+) {
+    MALE("남성"),
+    FEMALE("여성"),
+    UNKNOWN("모름"),
+    ;
+}

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberInitializeRequestVo.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberInitializeRequestVo.kt
@@ -1,9 +1,7 @@
 package mashup.backend.spring.acm.domain.member
 
-import mashup.backend.spring.acm.domain.perfume.Gender
-
 data class MemberInitializeRequestVo(
-    val gender: Gender,
+    val gender: MemberGender,
     val ageGroup: AgeGroup,
     val noteGroupIds: List<Long>?,
 )

--- a/acm-domain/src/test/kotlin/mashup/backend/spring/acm/domain/member/MemberServiceImplTest.kt
+++ b/acm-domain/src/test/kotlin/mashup/backend/spring/acm/domain/member/MemberServiceImplTest.kt
@@ -3,13 +3,11 @@ package mashup.backend.spring.acm.domain.member
 import mashup.backend.spring.acm.domain.member.idprovider.IdProviderInfo
 import mashup.backend.spring.acm.domain.member.idprovider.IdProviderType
 import mashup.backend.spring.acm.domain.member.idprovider.MemberIdProvider
-import mashup.backend.spring.acm.domain.perfume.Gender
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
-import java.time.Year
 
 @Transactional
 @SpringBootTest
@@ -40,7 +38,7 @@ internal class MemberServiceImplTest {
         val member = Member(
             memberDetail = MemberDetail(
                 name = "name",
-                gender = Gender.MAN,
+                gender = MemberGender.MALE,
                 ageGroup = AgeGroup.THIRTIES,
                 noteGroupIds = emptyList(),
             )


### PR DESCRIPTION
resolve #92 

향수는 MAN, WOMAN, UNISEX, UNKNOWN 으로 구분하지만
회원은 MALE, FEMALE, UNKNOWN 으로 구분해야해서 클래스 분리함