### PR TITLE
내 정보 조회시 noteGroup 목록 데이터 추가

### DIFF
--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/application/recommend/RecommendApplicationService.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/application/recommend/RecommendApplicationService.kt
@@ -6,6 +6,7 @@ import mashup.backend.spring.acm.application.member.MemberApplicationService
 import mashup.backend.spring.acm.domain.member.AgeGroup
 import mashup.backend.spring.acm.domain.member.MemberDetailVo
 import mashup.backend.spring.acm.domain.member.MemberStatus
+import mashup.backend.spring.acm.domain.note.NoteGroupService
 import mashup.backend.spring.acm.domain.perfume.PerfumeService
 import mashup.backend.spring.acm.domain.perfume.PerfumeSimpleVo
 import mashup.backend.spring.acm.domain.recommend.note.NoteRecommenderService
@@ -29,18 +30,21 @@ class RecommendApplicationServiceImpl(
     private val perfumeService: PerfumeService,
     private val perfumeRecommenderService: PerfumeRecommenderService,
     private val noteRecommenderService: NoteRecommenderService,
-    private val brandApplicationService: BrandApplicationService
+    private val brandApplicationService: BrandApplicationService,
+    private val noteGroupService: NoteGroupService,
 ): RecommendApplicationService {
     override fun recommendSimilarPerfumes(perfumeId: Long): List<SimpleRecommendPerfume> {
         log.info("[RECOMMEND_PERFUMES][recommendSimilarPerfumes] perfumeId=$perfumeId")
         val perfume = perfumeService.getPerfume(perfumeId)
+        val noteGroupIds = perfume.notes.mapNotNull { it.note.noteGroup?.id }.distinctBy { it }
         val memberForSimilarPerfumes = MemberDetailVo(
             id = -1L,
             status = MemberStatus.WITHDRAWAL,
             name = "memberForSimilarPerfumes",
             gender = perfume.gender.getMemberGender(),
             ageGroup = AgeGroup.UNKNOWN,
-            noteGroupIds = perfume.notes.mapNotNull { it.note.noteGroup?.id }.distinctBy { it }
+            noteGroupIds = noteGroupIds,
+            noteGroupSimpleVoList = noteGroupService.getNoteGroupsByIdIn(noteGroupIds = noteGroupIds),
         )
 
         return perfumeRecommenderService.recommendSimilarPerfumes(

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/infrastructure/scheduler/perfume/PerfumeScheduler.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/infrastructure/scheduler/perfume/PerfumeScheduler.kt
@@ -66,7 +66,8 @@ class PerfumeScheduler(
             name = "MOCK",
             gender = memberGender,
             ageGroup = AgeGroup.UNKNOWN,
-            noteGroupIds = emptyList()
+            noteGroupIds = emptyList(),
+            noteGroupSimpleVoList = emptyList(),
         )
     }
 

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberData.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/api/member/MemberData.kt
@@ -3,6 +3,7 @@ package mashup.backend.spring.acm.presentation.api.member
 import mashup.backend.spring.acm.domain.member.AgeGroup
 import mashup.backend.spring.acm.domain.member.MemberGender
 import mashup.backend.spring.acm.domain.member.idprovider.IdProviderType
+import mashup.backend.spring.acm.presentation.api.note.NoteGroupSimpleResponse
 import org.hibernate.validator.constraints.Length
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
@@ -30,6 +31,10 @@ data class MemberDetailResponse(
      * 나이대
      */
     val ageGroup: String?,
+    /**
+     * 노트 그룹
+     */
+    val noteGroups: List<NoteGroupSimpleResponse>,
 )
 
 data class LoginResponse(

--- a/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/assembler/MemberExtentions.kt
+++ b/acm-api/src/main/kotlin/mashup/backend/spring/acm/presentation/assembler/MemberExtentions.kt
@@ -4,7 +4,6 @@ import mashup.backend.spring.acm.domain.member.AgeGroup
 import mashup.backend.spring.acm.domain.member.MemberDetailVo
 import mashup.backend.spring.acm.domain.member.MemberGender
 import mashup.backend.spring.acm.domain.member.MemberInitializeRequestVo
-import mashup.backend.spring.acm.domain.perfume.Gender
 import mashup.backend.spring.acm.presentation.api.member.MemberDetailResponse
 import mashup.backend.spring.acm.presentation.api.member.MemberInfoResponse
 import mashup.backend.spring.acm.presentation.api.member.MemberInitializeRequest
@@ -14,7 +13,8 @@ fun MemberDetailVo.toMemberDetailResponse(): MemberDetailResponse = MemberDetail
     status = this.status.name,
     name = this.name,
     gender = this.gender.name,
-    ageGroup = this.ageGroup.name
+    ageGroup = this.ageGroup.name,
+    noteGroups = this.noteGroupSimpleVoList.map { it.toDto() }
 )
 
 fun MemberDetailVo.toMemberInfoResponse(): MemberInfoResponse = MemberInfoResponse(

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberDetailVo.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberDetailVo.kt
@@ -1,5 +1,6 @@
 package mashup.backend.spring.acm.domain.member
 
+import mashup.backend.spring.acm.domain.note.NoteGroupSimpleVo
 import mashup.backend.spring.acm.domain.perfume.Gender
 
 data class MemberDetailVo(
@@ -8,15 +9,17 @@ data class MemberDetailVo(
     val name: String?,
     val gender: MemberGender,
     val ageGroup: AgeGroup,
-    val noteGroupIds: List<Long>
+    val noteGroupIds: List<Long>,
+    val noteGroupSimpleVoList: List<NoteGroupSimpleVo>,
 ) {
-    constructor(member: Member) : this(
+    constructor(member: Member, noteGroupSimpleVoList: List<NoteGroupSimpleVo>) : this(
         id = member.id,
         status = member.memberStatus,
         name = member.memberDetail.name,
         gender = member.memberDetail.gender,
         ageGroup = member.memberDetail.ageGroup,
-        noteGroupIds = member.memberDetail.noteGroupIds
+        noteGroupIds = member.memberDetail.noteGroupIds,
+        noteGroupSimpleVoList = noteGroupSimpleVoList.toList(),
     )
 
     fun getPerfumeGender(): Gender {

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberService.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberService.kt
@@ -6,6 +6,7 @@ import mashup.backend.spring.acm.domain.exception.MemberNotFoundException
 import mashup.backend.spring.acm.domain.member.idprovider.IdProviderInfo
 import mashup.backend.spring.acm.domain.member.idprovider.MemberIdProvider
 import mashup.backend.spring.acm.domain.note.NoteGroupService
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
@@ -29,8 +30,11 @@ interface MemberService {
 class MemberServiceImpl(
     private val memberRepository: MemberRepository,
     private val memberDetailRepository: MemberDetailRepository,
-    private val noteGroupService: NoteGroupService,
 ) : MemberService {
+
+    @Autowired
+    lateinit var noteGroupService: NoteGroupService
+
     override fun findById(memberId: Long): Member? {
         return memberRepository.findByIdOrNull(memberId)
     }

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberService.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/member/MemberService.kt
@@ -35,26 +35,24 @@ class MemberServiceImpl(
         return memberRepository.findByIdOrNull(memberId)
     }
 
-    override fun findByIdProviderVo(idProviderInfo: IdProviderInfo): Member? {
-        return memberRepository.findByMemberIdProviders_IdProviderInfo(idProviderInfo)
-    }
+    override fun findByIdProviderVo(idProviderInfo: IdProviderInfo): Member? =
+        memberRepository.findByMemberIdProviders_IdProviderInfo(idProviderInfo)
 
-    override fun findDetailById(memberId: Long): MemberDetailVo {
-        return getMemberDetailById(memberId)
-    }
+    override fun findDetailById(memberId: Long): MemberDetailVo =
+        getMemberDetailById(memberId)
 
-    override fun findAllMemberDetail(): List<SimpleMemberDetailVo> {
-        return memberDetailRepository.findByNoteGroupIdsIsNotNull().map { SimpleMemberDetailVo(it) }
-    }
+    override fun findAllMemberDetail(): List<SimpleMemberDetailVo> =
+        memberDetailRepository.findByNoteGroupIdsIsNotNull()
+            .map { SimpleMemberDetailVo(it) }
 
     override fun getMembers(pageable: Pageable): Page<MemberDetailVo> =
         memberRepository.findAll(pageable)
-            .map {
-                MemberDetailVo(
-                    member = it,
-                    noteGroupSimpleVoList = noteGroupService.getNoteGroupsByIdIn(it.memberDetail.noteGroupIds)
-                )
-            }
+            .map { toMemberDetailVo(it) }
+
+    private fun toMemberDetailVo(member: Member): MemberDetailVo = MemberDetailVo(
+        member = member,
+        noteGroupSimpleVoList = noteGroupService.getNoteGroupsByIdIn(member.memberDetail.noteGroupIds)
+    )
 
     @Transactional
     override fun join(idProviderInfo: IdProviderInfo): MemberDetailVo {
@@ -76,14 +74,10 @@ class MemberServiceImpl(
         }
     }
 
-    private fun getMemberDetailById(memberId: Long): MemberDetailVo {
-        val member = memberRepository.findByIdOrNull(memberId)
+    private fun getMemberDetailById(memberId: Long): MemberDetailVo =
+        memberRepository.findByIdOrNull(memberId)
+            ?.let { toMemberDetailVo(it) }
             ?: throw MemberNotFoundException(memberId = memberId)
-        return MemberDetailVo(
-            member = member,
-            noteGroupSimpleVoList = noteGroupService.getNoteGroupsByIdIn(member.memberDetail.noteGroupIds)
-        )
-    }
 
     @Transactional
     override fun withdraw() {

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroupRepository.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroupRepository.kt
@@ -13,4 +13,6 @@ interface NoteGroupRepository : JpaRepository<NoteGroup, Long> {
 
     @Query(value = "SELECT ng FROM NoteGroup ng ORDER BY function('RAND')")
     fun findByRandom(pageable: Pageable): List<NoteGroup>
+
+    fun findByIdIn(noteGroupIds: Collection<Long>): List<NoteGroup>
 }

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroupService.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroupService.kt
@@ -26,6 +26,7 @@ interface NoteGroupService {
     fun getPopularNoteGroup(): NoteGroupDetailVo
     fun cachePutGetPopularNoteGroup(): NoteGroupDetailVo
     fun getNoteGroups(pageable: Pageable): Page<NoteGroup>
+    fun getNoteGroupsByIdIn(noteGroupIds: List<Long>): List<NoteGroupSimpleVo>
 }
 
 @Service
@@ -137,4 +138,8 @@ class NoteGroupServiceImpl(
     }
 
     override fun getNoteGroups(pageable: Pageable): Page<NoteGroup> = noteGroupRepository.findAll(pageable)
+
+    override fun getNoteGroupsByIdIn(noteGroupIds: List<Long>): List<NoteGroupSimpleVo> =
+        noteGroupRepository.findByIdIn(noteGroupIds = noteGroupIds)
+            .map { NoteGroupSimpleVo(it) }
 }

--- a/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroupService.kt
+++ b/acm-domain/src/main/kotlin/mashup/backend/spring/acm/domain/note/NoteGroupService.kt
@@ -7,6 +7,7 @@ import mashup.backend.spring.acm.domain.exception.PerfumeNotFoundException
 import mashup.backend.spring.acm.domain.member.MemberService
 import mashup.backend.spring.acm.domain.perfume.PerfumeRepository
 import mashup.backend.spring.acm.infrastructure.CacheType
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.CachePut
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Page
@@ -32,10 +33,12 @@ interface NoteGroupService {
 @Service
 @Transactional(readOnly = true)
 class NoteGroupServiceImpl(
-    private val memberService: MemberService,
     private val noteGroupRepository: NoteGroupRepository,
-    private val perfumeRepository: PerfumeRepository
+    private val perfumeRepository: PerfumeRepository,
 ) : NoteGroupService {
+    @Autowired
+    lateinit var memberService: MemberService
+
     @Transactional(readOnly = false)
     override fun create(noteGroupCreateVo: NoteGroupCreateVo): NoteGroup {
         if (noteGroupRepository.existsByOriginalName(noteGroupCreateVo.name)) {

--- a/acm-domain/src/test/kotlin/mashup/backend/spring/acm/domain/recommend/RecommenderTest.kt
+++ b/acm-domain/src/test/kotlin/mashup/backend/spring/acm/domain/recommend/RecommenderTest.kt
@@ -26,6 +26,7 @@ internal class RecommenderTest {
             gender = MemberGender.MALE,
             ageGroup = AgeGroup.TEENAGER,
             noteGroupIds = emptyList(),
+            noteGroupSimpleVoList = emptyList(),
         )
         // when
         val actual = perfumeRecommenderByGender.recommend(memberDetailVo = memberDetailVo, 3)


### PR DESCRIPTION
resolve #133 

내 정보 API (`/api/v1/members/me`) 조회시,

### AS-IS
noteGroup 관련 정보 없음
```json
{
  "code": "SUCCESS",
  "message": "성공",
  "data": {
    "member": {
      "id": 21177,
      "status": "ACTIVE",
      "name": "dobby2",
      "gender": "MALE",
      "ageGroup": "TEENAGER"
    }
  }
}
```

### TO-BE
noteGroups 필드 추가
```json
{
  "code": "SUCCESS",
  "message": "성공",
  "data": {
    "member": {
      "id": 21177,
      "status": "ACTIVE",
      "name": "dobby2",
      "gender": "MALE",
      "ageGroup": "TEENAGER",
      "noteGroups": [
        {
          "id": 21180,
          "name": "CITRUS SMELLS",
          "customName": "citrus_yellow"
        },
        {
          "id": 21181,
          "name": "FRUITS & VEGETABLES",
          "customName": "fruits&vegetables _purple"
        },
        {
          "id": 21182,
          "name": "FLOWERS",
          "customName": "flowers_pink"
        }
      ]
    }
  }
}
```